### PR TITLE
Fix Pi 5 onboard WiFi (BCM43455) attach failure

### DIFF
--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -128,6 +128,15 @@ define Package/brcmfmac-nvram-43455-sdio/install
 	$(LN) \
 		brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.Raspberry\ Pi\ Foundation-Raspberry\ Pi\ Compute\ Module\ 4.txt
+	$(LN) \
+		brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
+		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-model-b.txt
+	$(LN) \
+		brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
+		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module.txt
+	$(LN) \
+		brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
+		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,500.txt
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/brcm/brcmfmac43455-sdio.MINIX-NEO\ Z83-4.txt \
 		$(1)/lib/firmware/brcm/

--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -416,7 +416,10 @@ define KernelPackage/brcmfmac
   DEPENDS+= @USB_SUPPORT +kmod-cfg80211 +@DRIVER_11AC_SUPPORT \
   	+kmod-brcmutil +BRCMFMAC_SDIO:kmod-mmc @!TARGET_uml \
 	+BRCMFMAC_USB:kmod-usb-core +BRCMFMAC_USB:brcmfmac-firmware-usb
-  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/brcmfmac.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/bca/brcmfmac-bca.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cyw/brcmfmac-cyw.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/broadcom/brcm80211/brcmfmac/wcc/brcmfmac-wcc.ko
   AUTOLOAD:=$(call AutoProbe,brcmfmac)
 endef
 


### PR DESCRIPTION
## Summary

Two small packaging gaps were preventing the Pi 5's onboard CYW43455 (BCM43455) chip from attaching. Both are already flagged as a known issue in `AGENTS.md` ("Pi 5 onboard Wi-Fi (BCM43455) not working").

1. **`kmod-brcmfmac`'s `FILES` only listed the core `brcmfmac.ko`.** Since Linux 6.5, `brcmfmac` splits chip-vendor attach logic into separate modules (`brcmfmac-{bca,cyw,wcc}.ko`). These get built automatically whenever `brcmfmac` is built, but were never added to this package's `FILES`. Without `brcmfmac-wcc.ko` specifically, attach fails unconditionally with `brcmf_fwvid_request_module: mod=wcc: failed`.
2. **`brcmfmac-nvram-43455-sdio` had no Pi 5 entry.** It symlinks NVRAM calibration data for Pi 3/4 board names, but nothing for `raspberrypi,5-model-b` / `5-compute-module` / `500`, so even with the module fix, the driver has nowhere to find calibration data for a Pi 5.

## Fix

- Added the three vendor `.ko` files to `kmod-brcmfmac`'s `FILES`.
- Added Pi 5 NVRAM symlinks reusing the existing Pi 4 data (same chip, same reference antenna design).

## Verification

Built from source and tested on real Pi 5 hardware. Before the fix: `brcmf_fwvid_request_module: mod=wcc: failed`, then `brcmf_attach failed`. After:

```
brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43455-sdio for chip BCM4345/6
brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4345/6 wl0: Jul 29 2022 02:15:20 version 7.45.250 (70e9766 CY) FWID 01-e53e306b
```

```
$ iw dev
phy#1
    Interface wlan0
        addr 88:a2:9e:de:b7:f5
        type managed
```

The onboard radio comes up as a normal `wlan0` alongside the HaLow radio.

Note: while testing, I also found that `/etc/init.d/morsechipreset`'s GPIO reset (intended for the SPI-connected HaLow HAT) currently fails to resolve its GPIO line (`unable to reset as MM_RESET is not in gpio-line-names or is duplicated in device tree`) and appears to take down the entire onboard WiFi SDIO controller as a side effect during boot. Disabling that init script is what let the chip stay attached long enough to verify this fix. That's a separate, pre-existing issue unrelated to this patch, so I've left it out of this PR. Happy to file it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
